### PR TITLE
Remove links to ez3ds

### DIFF
--- a/addons/assistance.py
+++ b/addons/assistance.py
@@ -63,11 +63,6 @@ class Assistance:
         embed.description = "Free 3DS Primary Entrypoint <= 11.2"
         await self.bot.say("", embed=embed)
 
-    @commands.command()
-    async def ez(self):
-        """Links to ez3ds."""
-        await self.simple_embed("Start here to discover how to hack your 3DS: https://ez3ds.xyz")
-
     # 9.6 xml command
     @commands.command()
     async def xmls(self):
@@ -136,11 +131,6 @@ class Assistance:
     async def s4guide(self):
         """Links to a guide for Sm4sh 3ds mods."""
         await self.simple_embed("A guide to setting up mods for smash on your 3ds can be found here: https://github.com/KotuMF/Smash-3DS-Modding-Guide/wiki")
-
-    @commands.command(pass_context=True, name="ez2")
-    async def ez2(self, ctx, model: str, major: int, minor: int, revision: int, nver: int, region: str, ):
-        """Gives you the direct link to your version's page.\nExample: !ez2 Old 11 0 0 33 E"""
-        await self.simple_embed("https://ez3ds.xyz/checkfw?model={0}&major={1}&minor={2}&revision={3}&nver={4}&region={5}".format(model, major, minor, revision, nver, region))
 
     @commands.command()
     async def brick(self):


### PR DESCRIPTION
Remove links to outdated guide that is seldomly referred to nowadays.