### PR TITLE
Add .redscr

### DIFF
--- a/addons/assistance.py
+++ b/addons/assistance.py
@@ -238,9 +238,9 @@ class Assistance:
         embed.description = "Intructions on how to fix a broken TWL after doing the guide"
         await self.bot.say("", embed=embed)
         
-        @commands.command()
+     @commands.command()
     async def redscr(self):
-        """How to check your IP"""
+        """Help with homebrew red screen"""
         await self.simple_embed("A red screen indicates that there is no boot.3dsx on root.\nIf you have a starter folder on root, place the contents of the starter folder on root.\nIf not, redownload the Homebrew Starter Kit and place the contents of the starter folder inside the .zip on root.", title="If you get a red screen trying to open the Homebrew Launcher")
 
 def setup(bot):

--- a/addons/assistance.py
+++ b/addons/assistance.py
@@ -237,6 +237,11 @@ class Assistance:
         embed.url = "https://3ds.guide/troubleshooting#twl_broken"
         embed.description = "Intructions on how to fix a broken TWL after doing the guide"
         await self.bot.say("", embed=embed)
+        
+        @commands.command()
+    async def redscr(self):
+        """How to check your IP"""
+        await self.simple_embed("A red screen indicates that there is no boot.3dsx on root.\nIf you have a starter folder on root, place the contents of the starter folder on root.\nIf not, redownload the Homebrew Starter Kit and place the contents of the starter folder inside the .zip on root.", title="If you get a red screen trying to open the Homebrew Launcher")
 
 def setup(bot):
     bot.add_cog(Assistance(bot))

--- a/addons/assistance.py
+++ b/addons/assistance.py
@@ -238,7 +238,7 @@ class Assistance:
         embed.description = "Intructions on how to fix a broken TWL after doing the guide"
         await self.bot.say("", embed=embed)
         
-     @commands.command()
+    @commands.command()
     async def redscr(self):
         """Help with homebrew red screen"""
         await self.simple_embed("A red screen indicates that there is no boot.3dsx on root.\nIf you have a starter folder on root, place the contents of the starter folder on root.\nIf not, redownload the Homebrew Starter Kit and place the contents of the starter folder inside the .zip on root.", title="If you get a red screen trying to open the Homebrew Launcher")


### PR DESCRIPTION
If you get a red screen trying to open the Homebrew Launcher:
A red screen indicates that there is no boot.3dsx on root.
If you have a starter folder on root, place the contents of the starter folder on root.
If not, redownload the Homebrew Starter Kit and place the contents of the starter folder inside the .zip on root.