### PR TITLE
Add FBI maki edition as a piracy tool

### DIFF
--- a/addons/events.py
+++ b/addons/events.py
@@ -53,6 +53,8 @@ class Events:
         'freeshoandp',
         'freeshothenp',
         'freeeshop',
+        'makiedition',
+        'makiversion',
         'utikdownloadhelper',
         'wiiuusbhelper',
     ]


### PR DESCRIPTION
The only reason one would launch FBI maki edition would be if they do not have CFW, in which case the only installable CIAs would be the "legit" (pirated) ones