### PR TITLE
Added Nintendo error 032-1820

### DIFF
--- a/addons/err.py
+++ b/addons/err.py
@@ -236,6 +236,7 @@ class Err:
         '022-2631': 'Nintendo Network ID deleted, or not usable on the current system. If you used System Transfer, the Nintendo Network ID will only work on the target system.',
         '022-2634': 'Nintendo Network ID is not correctly linked on the system. This can be a result of formatting the SysNAND using System Settings to unlink it from the EmuNAND.\n\n<steps on how to fix>\n\nTinyFormat is recommended for unlinking in the future.',
         '022-2812': 'System is banned by Nintendo. You cannot ask how to fix this issue here.',
+        '032-1820': 'Browser error that asks whether you want to go on to a potentially dangerous website. Can be bypassed by touching "yes".',
         '090-0212': 'Game is banned from Pokémon Global Link. This is most likely as a result of using altered or illegal save data.',
         # Wii U
         '160-0102': 'Error in SLC/MLC or USB.',


### PR DESCRIPTION
Added Nintendo error 032-1820 (which is basically a confirmation to move on to potentially dangerous page [including the Team Kirby Clash DX NTR plugin page])