### PR TITLE
added an else clause to fix erroneous DM

### DIFF
--- a/addons/extras.py
+++ b/addons/extras.py
@@ -151,7 +151,7 @@ class Extras:
             else:
                 await self.bot.add_roles(author, self.bot.elsewhere_role)
                 await self.bot.send_message(author, "Access to #elsewhere granted.")
-        if channelname == "eventchat":
+        else if channelname == "eventchat":
             if self.bot.eventchat_role in author.roles:
                 await self.bot.remove_roles(author, self.bot.eventchat_role)
                 await self.bot.send_message(author, "Access to #eventchat granted.")


### PR DESCRIPTION
I spotted a silly error, wherein whenever anyone performs `.togglechannel elsewhere`, Kurisu DMs them with both the toggle confirmation AND `elsewhere is not a valid toggleable channel.`

I decided to fix it, and did so in literally four letters.
¯\\_(ツ)_/¯ It bothered me, m'kay?
