### PR TITLE
fix silly DM error (now with good syntax)

### DIFF
--- a/addons/extras.py
+++ b/addons/extras.py
@@ -151,7 +151,7 @@ class Extras:
             else:
                 await self.bot.add_roles(author, self.bot.elsewhere_role)
                 await self.bot.send_message(author, "Access to #elsewhere granted.")
-        if channelname == "eventchat":
+        elif channelname == "eventchat":
             if self.bot.eventchat_role in author.roles:
                 await self.bot.remove_roles(author, self.bot.eventchat_role)
                 await self.bot.send_message(author, "Access to #eventchat granted.")


### PR DESCRIPTION
Resubmission of a previous pull because I'm an idiot and forgot how Python worked.

Kurisu was reporting to a user that uses `.togglechannel elsewhere` that `elsewhere is not a valid toggleable channel.` - this fixes that.
